### PR TITLE
Set up a skeletal Terraform configuration for production infra

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Terraform working dir settings
+.terraform/
+
+# Terraform local state files.  These shouldn't exist with our remote state
+# store, but in case they do, make sure they aren't committed.
+terraform.tfstate*
+
+# Terraform plans, per our suggested usage in (nextstrain.org) docs
+/env/*/plan

--- a/env/production/.terraform.lock.hcl
+++ b/env/production/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.67.0"
+  constraints = "~> 4.32"
+  hashes = [
+    "h1:dCRc4GqsyfqHEMjgtlM1EympBcgTmcTkWaJmtd91+KA=",
+    "zh:0843017ecc24385f2b45f2c5fce79dc25b258e50d516877b3affee3bef34f060",
+    "zh:19876066cfa60de91834ec569a6448dab8c2518b8a71b5ca870b2444febddac6",
+    "zh:24995686b2ad88c1ffaa242e36eee791fc6070e6144f418048c4ce24d0ba5183",
+    "zh:4a002990b9f4d6d225d82cb2fb8805789ffef791999ee5d9cb1fef579aeff8f1",
+    "zh:559a2b5ace06b878c6de3ecf19b94fbae3512562f7a51e930674b16c2f606e29",
+    "zh:6a07da13b86b9753b95d4d8218f6dae874cf34699bca1470d6effbb4dee7f4b7",
+    "zh:768b3bfd126c3b77dc975c7c0e5db3207e4f9997cf41aa3385c63206242ba043",
+    "zh:7be5177e698d4b547083cc738b977742d70ed68487ce6f49ecd0c94dbf9d1362",
+    "zh:8b562a818915fb0d85959257095251a05c76f3467caa3ba95c583ba5fe043f9b",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9c385d03a958b54e2afd5279cd8c7cbdd2d6ca5c7d6a333e61092331f38af7cf",
+    "zh:b3ca45f2821a89af417787df8289cb4314b273d29555ad3b2a5ab98bb4816b3b",
+    "zh:da3c317f1db2469615ab40aa6baba63b5643bae7110ff855277a1fb9d8eb4f2c",
+    "zh:dc6430622a8dc5cdab359a8704aec81d3825ea1d305bbb3bbd032b1c6adfae0c",
+    "zh:fac0d2ddeadf9ec53da87922f666e1e73a603a611c57bcbc4b86ac2821619b1d",
+  ]
+}

--- a/env/production/terraform.tf
+++ b/env/production/terraform.tf
@@ -1,0 +1,27 @@
+terraform {
+  required_version = ">= 1.5.0"
+  required_providers {
+    aws = {
+      source  = "registry.terraform.io/hashicorp/aws"
+      version = "~> 4.32"
+    }
+  }
+
+  backend "s3" {
+    region = "us-east-1"
+
+    # Default workspace uses s3://nextstrain-terraform/infra/production/tfstate
+    bucket = "nextstrain-terraform"
+    key    = "infra/production/tfstate"
+
+    # Non-default workspaces use s3://nextstrain-terraform/workspace/${name}/infra/production/tfstate
+    workspace_key_prefix = "workspace"
+
+    # Table has a LockID (string) partition/primary key
+    dynamodb_table = "nextstrain-terraform-locks"
+  }
+}
+
+provider "aws" {
+  region = "us-east-1"
+}


### PR DESCRIPTION
State backend and AWS provider.  A single configuration for now but a layout amenable to the expectation of multiple configurations in the future.

The directory name is "env", not "terraform", because I expect these directories to house additional non-Terraform files needed for each environment.  Snippets shared between the configurations can then live directly under env/ and be symlinked.

Multiple configurations using local modules are the primary and recommended¹ way to have multiple environments that are similar but not identical.  Terraform "workspaces" are another way manage multiple environments, but they're intended for multiple instances of a single configuration.²  You can parameterize the configuration on the workspace name, but it's harder to express larger scale divergence (different resources, different modules) with just parameterization due to the lack of any top-level conditional constructs.

Cribbed-from: <https://github.com/nextstrain/nextstrain.org/commit/5921be61>

¹ c.f. <https://developer.hashicorp.com/terraform/tutorials/modules/organize-configuration>
² <https://developer.hashicorp.com/terraform/cli/workspaces#use-cases>