### PR TITLE
Tag each pathogen repo with the "nextstrain" and "pathogen" GitHub topics

### DIFF
--- a/env/production/github-repos.tf
+++ b/env/production/github-repos.tf
@@ -1,0 +1,5 @@
+resource "github_repository_topics" "nextstrain" {
+  for_each = toset(flatten(values(local.pathogen_repos)))
+  repository = each.key
+  topics = ["nextstrain", "pathogen"]
+}


### PR DESCRIPTION
A minor thing but the "pathogen" tag can help us easily list and search within our pathogen repos on GitHub, e.g.

    https://github.com/search?q=org:nextstrain+topic:pathogen

We often use GitHub search to find code usages across repos or find replicated issues/PRs, so having way to filter down to just pathogen repos (vs. other software repos) is handy.

The "nextstrain" and "pathogen" topic tags are both in separate use more widely¹, but not currently used together.² There's a decent chance Nextstrain community users will adopt the same tag pair by intentionally following our example or by forking our repos, so we may become able to use both tags to narrow down results when searching outside our org. This would be neat for discovery.

An alternative I considered is using one topic, "nextstrain-pathogen", but that seemed less desirable when considering that the existing "nextstrain" and "pathogen" tags would also apply.

¹ <https://github.com/topics/nextstrain> <https://github.com/topics/pathogen>
² <https://github.com/search?q=topic:nextstrain+topic:pathogen>


## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
