### PR TITLE
Preserve existing repo topic tags when adding "nextstrain" and "pathogen"

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,14 @@ Make those changes so:
 > You'll need ambiently-configured AWS credentials with broad admin-level
 > access to read (and optionally modify) resources in our account.
 >
-> You'll also need a `GITHUB_TOKEN` in the environment with the `actions:write`
-> fine-grained token permission on our repos.
+> You'll also need a `GITHUB_TOKEN` in the environment with the following
+> fine-grained token permissions on our repos:
 >
-> Please step cautiously and be careful when using them!
+>   - `actions:write`
+>   - `administration:write`
+>
+> Please step cautiously and be careful when using these two sets of
+> credentials!
 
 
 ## Documentation

--- a/env/production/github-repos.tf
+++ b/env/production/github-repos.tf
@@ -1,5 +1,10 @@
-resource "github_repository_topics" "nextstrain" {
+data "github_repository" "pathogen" {
   for_each = toset(flatten(values(local.pathogen_repos)))
+  name = each.key
+}
+
+resource "github_repository_topics" "pathogen" {
+  for_each = data.github_repository.pathogen
   repository = each.key
-  topics = ["nextstrain", "pathogen"]
+  topics = toset(flatten([each.value.topics, "nextstrain", "pathogen"]))
 }


### PR DESCRIPTION
I realized before deploying "Tag each pathogen repo with the "nextstrain" and "pathogen" GitHub topics" (a80ad9a) that it would _replace_ all topics instead of amending/extending them.

Additionally, note the necessary fine-grained permission to set repo topics in the README.  The lack of this permission on my admin token was what led to me to realizing that topics are always set en masse instead of added/removed individually, as I looked up the permission necessary on the API endpoint and noticed its documented behaviour.

Related-to: <https://github.com/nextstrain/infra/pull/9>

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
