### PR TITLE
Allow pathogen workflows to perform CloudFront invalidations…

### DIFF
--- a/env/production/aws-iam-policy-NextstrainPathogen@.tf
+++ b/env/production/aws-iam-policy-NextstrainPathogen@.tf
@@ -70,6 +70,22 @@ resource "aws_iam_policy" "NextstrainPathogen" {
           "arn:aws:s3:::nextstrain-staging/files/datasets/${each.key}/*",
         ],
       },
+      {
+        "Sid": "CloudFront",
+        "Effect": "Allow",
+        "Action": [
+          "cloudfront:ListDistributions",
+          "cloudfront:CreateInvalidation",
+          "cloudfront:GetInvalidation",
+        ],
+        # XXX TODO: Import CloudFront resources into Terraform and pull their
+        # IDs dynamically instead of hardcoding them here.
+        #   -trs, 31 May 2024
+        "Resource": [
+          "arn:aws:cloudfront:::distribution/E3LB0EWZKCCV",   # data.nextstrain.org
+          "arn:aws:cloudfront:::distribution/E3L83FTHWUN0BV", # staging.nextstrain.org
+        ],
+      }
     ]
   })
 }


### PR DESCRIPTION
…for the {data,staging}.nextstrain.org distributions.

This is a more tightly scoped policy than the policy often used, "AllowCloudfrontInvalidations".  I think that policy is too broad but don't want to change it directly out of concerns for off-target effects.

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
