### PR TITLE
Fix CloudFront permissions policy

### DIFF
--- a/env/production/aws-iam-policy-NextstrainPathogen@.tf
+++ b/env/production/aws-iam-policy-NextstrainPathogen@.tf
@@ -71,10 +71,17 @@ resource "aws_iam_policy" "NextstrainPathogen" {
         ],
       },
       {
-        "Sid": "CloudFront",
+        "Sid": "CloudFrontList",
         "Effect": "Allow",
         "Action": [
           "cloudfront:ListDistributions",
+        ],
+        "Resource": "*",
+      },
+      {
+        "Sid": "CloudFrontReadWrite",
+        "Effect": "Allow",
+        "Action": [
           "cloudfront:CreateInvalidation",
           "cloudfront:GetInvalidation",
         ],
@@ -82,8 +89,8 @@ resource "aws_iam_policy" "NextstrainPathogen" {
         # IDs dynamically instead of hardcoding them here.
         #   -trs, 31 May 2024
         "Resource": [
-          "arn:aws:cloudfront:::distribution/E3LB0EWZKCCV",   # data.nextstrain.org
-          "arn:aws:cloudfront:::distribution/E3L83FTHWUN0BV", # staging.nextstrain.org
+          "arn:aws:cloudfront::827581582529:distribution/E3LB0EWZKCCV",   # data.nextstrain.org
+          "arn:aws:cloudfront::827581582529:distribution/E3L83FTHWUN0BV", # staging.nextstrain.org
         ],
       }
     ]


### PR DESCRIPTION
The cloudfront:ListDistributions action doesn't allow limiting by distribution: it only supports all or nothing.  I misread the table of resource keys supported by actions.  orz

The actions that do support limiting by distribution require an explicit account id in the ARN.  It can't be blank like S3; it must be an actual account id or a wildcard.

¹ <https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazoncloudfront.html#amazoncloudfront-ListDistributions>

Related-to: <https://github.com/nextstrain/infra/pull/12>
Related-to: <https://github.com/nextstrain/zika/pull/59#issuecomment-2145973141>

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
