### PR TITLE
Special-case forecasts-ncov to give it read-only access to nextstrain-ncov-private

### DIFF
--- a/env/production/aws-iam-policy-NextstrainPathogenNcovPrivate.tf
+++ b/env/production/aws-iam-policy-NextstrainPathogenNcovPrivate.tf
@@ -41,3 +41,41 @@ resource "aws_iam_policy" "NextstrainPathogenNcovPrivate" {
     ]
   })
 }
+
+resource "aws_iam_policy" "NextstrainPathogenNcovPrivateReadOnly" {
+  name = "NextstrainPathogen@ncov+private-read-only"
+  description = "Provides permissions to read datasets, workflow files, etc. in the ncov-private bucket for the Nextstrain ncov pathogen"
+
+  policy = jsonencode({
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Sid": "NcovPrivateList",
+        "Effect": "Allow",
+        "Action": [
+          "s3:ListBucket",
+          "s3:ListBucketVersions",
+          "s3:GetBucketLocation",
+          "s3:GetBucketVersioning",
+        ],
+        "Resource": [
+          "arn:aws:s3:::nextstrain-ncov-private",
+        ],
+      },
+      {
+        "Sid": "NcovPrivateReadWrite",
+        "Effect": "Allow",
+        "Action": [
+          "s3:GetObject",
+          "s3:GetObjectTagging",
+          "s3:GetObjectVersion",
+          "s3:GetObjectVersionTagging",
+        ],
+        "Resource": [
+          # This bucket is akin to nextstrain-data-private/files/{workflows,datasets}/ncov/.
+          "arn:aws:s3:::nextstrain-ncov-private/*",
+        ],
+      },
+    ]
+  })
+}

--- a/env/production/aws-iam-role-GitHubActionsRoleNextstrainRepo@.tf
+++ b/env/production/aws-iam-role-GitHubActionsRoleNextstrainRepo@.tf
@@ -35,6 +35,11 @@ resource "aws_iam_role" "GitHubActionsRoleNextstrainRepo" {
       ? [aws_iam_policy.NextstrainPathogenNcovPrivate.arn]
       : [],
 
+    # Special-case forecasts-ncov
+    each.key == "forecasts-ncov"
+      ? [aws_iam_policy.NextstrainPathogenNcovPrivateReadOnly.arn]
+      : [],
+
     # Builds inside the AWS Batch runtime need access to the jobs bucket.
     aws_iam_policy.NextstrainJobsAccessToBucket.arn,
   ])


### PR DESCRIPTION
It needs read-only access to (at least)
<s3://nextstrain-ncov-private/metadata.tsv.zst>, and special-casing it is the quick and easy way to do that.

The forecasts-ncov repo is conceptually-speaking maybe best thought of as a forecasts/ directory within the ncov repo, similar to how the ncov-ingest repo is best thought of as an ingest/ directory within the same.¹  Unlike ncov-ingest, however, forecasts-ncov publishes files under its own name at <s3://nextstrain-data/files/workflows/forecasts-ncov/> instead of ncov's name.  This is why it appears as its own "pathogen", a conceptual confusion and one that means it gets unnecessary access to write <s3://nextstrain-data/forecasts_ncov….json>.

We could choose to better address this some day, if the pattern of data-generating repos downstream of pathogen repos proliferates, by conceptually separating the two things in this Terraform configuration.

Related-to: <https://github.com/nextstrain/private/issues/110>
Alternative-to: <https://github.com/nextstrain/infra/pull/15>

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
