### PR TITLE
Allow ncov pathogen repos to access non-standard files/ncov/ paths in S3

### DIFF
--- a/env/production/aws-iam-policy-NextstrainPathogenNcovNonStandardPaths.tf
+++ b/env/production/aws-iam-policy-NextstrainPathogenNcovNonStandardPaths.tf
@@ -1,0 +1,51 @@
+# Single-pathogen policy, special-case for the historical reason that
+# ncov uses the non-standard files/ncov/ paths.
+resource "aws_iam_policy" "NextstrainPathogenNcovNonStandardPaths" {
+  name = "NextstrainPathogen@ncov+non-standard-paths"
+  description = "Provides permissions to upload workflow files for the Nextstrain ncov pathogen to its non-standard paths"
+
+  policy = jsonencode({
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Sid": "List",
+        "Effect": "Allow",
+        "Action": [
+          "s3:ListBucket",
+          "s3:ListBucketVersions",
+          "s3:GetBucketLocation",
+          "s3:GetBucketVersioning",
+        ],
+        "Resource": [
+          "arn:aws:s3:::nextstrain-data",
+          "arn:aws:s3:::nextstrain-staging",
+        ],
+        "Condition": {
+          "StringLike": {
+            "s3:prefix": [
+              "files/ncov/*",
+            ]
+          }
+        }
+      },
+      {
+        "Sid": "ReadWrite",
+        "Effect": "Allow",
+        "Action": [
+          "s3:GetObject",
+          "s3:GetObjectTagging",
+          "s3:GetObjectVersion",
+          "s3:GetObjectVersionTagging",
+          "s3:PutObject",
+          "s3:PutObjectTagging",
+          "s3:DeleteObject",
+          # but NOT s3:DeleteObjectVersion so objects can't be completely wiped
+        ],
+        "Resource": [
+          "arn:aws:s3:::nextstrain-data/files/ncov/*",
+          "arn:aws:s3:::nextstrain-staging/files/ncov/*",
+        ],
+      },
+    ]
+  })
+}

--- a/env/production/aws-iam-role-GitHubActionsRoleNextstrainRepo@.tf
+++ b/env/production/aws-iam-role-GitHubActionsRoleNextstrainRepo@.tf
@@ -30,12 +30,13 @@ resource "aws_iam_role" "GitHubActionsRoleNextstrainRepo" {
     # Pathogen-specific permissions to standard public/private buckets
     [for p in each.value: aws_iam_policy.NextstrainPathogen[p].arn],
 
-    # Special-case permissions to nextstrain-ncov-private bucket
+    # Special-case repos associated with ncov
     contains(each.value, "ncov")
-      ? [aws_iam_policy.NextstrainPathogenNcovPrivate.arn]
+      ? [aws_iam_policy.NextstrainPathogenNcovPrivate.arn,
+         aws_iam_policy.NextstrainPathogenNcovNonStandardPaths.arn]
       : [],
 
-    # Special-case forecasts-ncov
+    # Special-case forecasts-ncov repo
     each.key == "forecasts-ncov"
       ? [aws_iam_policy.NextstrainPathogenNcovPrivateReadOnly.arn]
       : [],


### PR DESCRIPTION
These predate our data files conventions.¹  We haven't moved them over to files/{workflows,datasets}/ncov/ and might never.

Implemented as another additional policy to a) parallel the existing additional policy (NextstrainPathogenNcovPrivate) and b) keep NextstrainPathogen@ policies unconditionalized as our "desired standard".  The alternative would have been adding conditionally-included paths to the s3:prefix and Resource bits of the NextstrainPathogen@ policy just for ncov.  By keeping our standard policy unconditionalized, it makes it easier to reason about, at the expense of some policy statement duplication.

¹ <https://docs.nextstrain.org/en/latest/reference/data-files.html>

Related-to: <https://github.com/nextstrain/private/issues/110>

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
