### PR TITLE
Allow seasonal-flu/* to assume GitHubActionsRoleNextstrainBatchJobs

### DIFF
--- a/env/production/aws-iam-role-GitHubActionsRoleNextstrainBatchJobs.tf
+++ b/env/production/aws-iam-role-GitHubActionsRoleNextstrainBatchJobs.tf
@@ -22,10 +22,19 @@ resource "aws_iam_role" "GitHubActionsRoleNextstrainBatchJobs" {
         "Condition": {
           "StringLike": {
             "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
-            "token.actions.githubusercontent.com:sub": [
-              for repo in keys(local.repo_pathogens):
-                "repo:nextstrain/${repo}:*:job_workflow_ref:nextstrain/.github/.github/workflows/pathogen-repo-build.yaml@*"
-            ]
+            "token.actions.githubusercontent.com:sub": flatten([
+              [for repo in keys(local.repo_pathogens):
+                "repo:nextstrain/${repo}:*:job_workflow_ref:nextstrain/.github/.github/workflows/pathogen-repo-build.yaml@*:workflow_ref:*"],
+
+              # Special case for seasonal flu repo which needs to download the private builds
+              # from AWS Batch before bundling/deploying them through Netlify.
+              # We attempted to use the custom claim `workflow_ref` in
+              # https://github.com/nextstrain/infra/pull/19/commits/538385e4d1acd5359825e22f505f4d8bd073c2bf but
+              # that did not work as expected, so just allow any seasonal-flu GH Action workflow to access Batch.
+              # This special case can be removed when we finally sunset the private site.
+              #   -Jover, 07 June 2024
+              "repo:nextstrain/seasonal-flu:*",
+            ])
           }
         },
       }


### PR DESCRIPTION
We cannot use the usual `pathogen-repo-build` workflow for the seasonal flu deploy-private-nextflu workflow because these are private builds that should not be surfaced through public GH Action artifacts.¹

¹ <https://github.com/nextstrain/private/issues/110#issuecomment-2155212036>

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
