### PR TITLE
Clarify pathogen_repos list

### DIFF
--- a/env/production/locals.tf
+++ b/env/production/locals.tf
@@ -7,6 +7,8 @@ locals {
   # our needs.
   #   -trs, 20 May 2024
 
+  # These are pathogen repos that are using pathogen-repo-build. There are other
+  # pathogen repos that have not been automated yet that are not included here.
   pathogen_repos = tomap({
     # pathogen name   = [repo name, …]
     "avian-flu"       = ["avian-flu"],


### PR DESCRIPTION
## Description of proposed changes

I noticed that this list was missing some repos that could be considered "pathogen repos". Added a comment describing why that is.

## Related issue(s)

Thought of this while looking at the TODO list on https://github.com/nextstrain/pathogen-repo-guide/issues/46

## Checklist

- [x] Checks pass
