### PR TITLE
Add `wnv` to supported pathogen repos

### DIFF
--- a/env/production/locals.tf
+++ b/env/production/locals.tf
@@ -23,6 +23,7 @@ locals {
     "rsv"             = ["rsv"],
     "seasonal-cov"    = ["seasonal-cov"],
     "seasonal-flu"    = ["seasonal-flu"],
+    "wnv"             = ["wnv"],
     "zika"            = ["zika"],
   })
 


### PR DESCRIPTION
## Description of proposed changes

Prompted by nextstrain/wnv#13 which includes
the addition of a GH Action workflow that uses pathogen-repo-build workflow.

## Checklist

- [x] Checks pass

