### PR TITLE
fixup: wnv to WNV

### DIFF
--- a/env/production/locals.tf
+++ b/env/production/locals.tf
@@ -23,7 +23,7 @@ locals {
     "rsv"             = ["rsv"],
     "seasonal-cov"    = ["seasonal-cov"],
     "seasonal-flu"    = ["seasonal-flu"],
-    "wnv"             = ["wnv"],
+    "WNV"             = ["WNV"],
     "zika"            = ["zika"],
   })
 


### PR DESCRIPTION


## Description of proposed changes

Hotfix for https://github.com/nextstrain/infra/pull/29, needs to exactly match the github repo capitalization (`wnv`->`WNV`)

## Related issue(s)


## Checklist

- [x] Checks pass

```
# Double check the plan will delete wnv and create WNV
terraform -chdir=env/production plan -out=plan
...
  # github_repository_topics.pathogen["wnv"] will be destroyed
  # (because key ["wnv"] is not in for_each map)
  - resource "github_repository_topics" "pathogen" {
      - id         = "wnv" -> null
      - repository = "wnv" -> null
      - topics     = [
          - "nextstrain",
          - "pathogen",
        ] -> null
    }

Plan: 4 to add, 1 to change, 4 to destroy.
```