### PR TITLE
Add `nipah` to supported pathogen repos

### DIFF
--- a/env/production/locals.tf
+++ b/env/production/locals.tf
@@ -18,6 +18,7 @@ locals {
     "measles"         = ["measles"],
     "mpox"            = ["mpox"],
     "ncov"            = ["ncov", "ncov-ingest"],
+    "nipah"           = ["nipah"],
     "oropouche"       = ["oropouche"],
     "rabies"          = ["rabies"],
     "rsv"             = ["rsv"],


### PR DESCRIPTION
## Description of proposed changes

Prompted by https://github.com/nextstrain/nipah/pull/5 which includes the addition of a GH Action workflow that uses pathogen-repo-build workflow.

## Checklist

- [ ] Checks pass
