### PR TITLE
Add human-metapneumovirus to supported pathogen repos

### DIFF
--- a/env/production/locals.tf
+++ b/env/production/locals.tf
@@ -14,6 +14,7 @@ locals {
     "avian-flu"       = ["avian-flu"],
     "dengue"          = ["dengue"],
     "forecasts-ncov"  = ["forecasts-ncov"],
+    "hmpv"            = ["hmpv"],
     "lassa"           = ["lassa"],
     "measles"         = ["measles"],
     "mpox"            = ["mpox"],


### PR DESCRIPTION
## Description of proposed changes

As discussed in [PR review](https://github.com/nextstrain/infra/pull/34#discussion_r1882936107), the repo was renamed to `hmpv` to match the dataset names.

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
