### PR TITLE
terraform-lint: Bump to `ubuntu-24.04`

### DIFF
--- a/.github/workflows/terraform-lint.yml
+++ b/.github/workflows/terraform-lint.yml
@@ -6,6 +6,7 @@ on:
     tags-ignore:
       - '**'
     paths:
+      - '.github/workflows/terraform-lint.yml'
       - '**.tf'
       - '**.tfvars'
       - '**.tf.json'

--- a/.github/workflows/terraform-lint.yml
+++ b/.github/workflows/terraform-lint.yml
@@ -21,8 +21,18 @@ jobs:
       matrix:
         env:
           - env/production
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
+      - name: Install Terraform
+        run: >
+          wget -O - https://apt.releases.hashicorp.com/gpg
+          | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
+
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
+          | sudo tee /etc/apt/sources.list.d/hashicorp.list
+
+          sudo apt update && sudo apt install terraform
+
       - uses: actions/checkout@v4
 
       - run: terraform init -backend=false

--- a/.github/workflows/terraform-lint.yml
+++ b/.github/workflows/terraform-lint.yml
@@ -24,14 +24,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Install Terraform
-        run: >
-          wget -O - https://apt.releases.hashicorp.com/gpg
-          | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
-
-          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
-          | sudo tee /etc/apt/sources.list.d/hashicorp.list
-
-          sudo apt update && sudo apt install terraform
+        run: |
+          wget -O terraform.zip https://releases.hashicorp.com/terraform/1.10.2/terraform_1.10.2_linux_amd64.zip
+          unzip terraform.zip -d "$HOME/terraform"
+          echo "$HOME/terraform" >> "$GITHUB_PATH"
 
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Description of proposed changes

Since Terraform is no longer available, we have to install it as the
first step in the job. Installation commands copied from
<https://developer.hashicorp.com/terraform/install#linux>

## Related issue(s)

Related to https://github.com/nextstrain/.github/issues/113

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
