### PR TITLE
Add `mumps` to supported pathogen repos

### DIFF
--- a/env/production/locals.tf
+++ b/env/production/locals.tf
@@ -17,6 +17,7 @@ locals {
     "hmpv"            = ["hmpv"],
     "lassa"           = ["lassa"],
     "measles"         = ["measles"],
+    "mumps"           = ["mumps"],
     "mpox"            = ["mpox"],
     "ncov"            = ["ncov", "ncov-ingest"],
     "nipah"           = ["nipah"],


### PR DESCRIPTION
## Description of proposed changes

Prompted by https://github.com/nextstrain/mumps/pull/20 which includes the addition of a GH Action workflow that uses pathogen-repo-build workflow

## Checklist

- [x] Checks pass
- [x] `Apply complete! Resources: 4 added, 1 changed, 0 destroyed.`
