### PR TITLE
Switch deprecated `dynamodb_table` for supported `use_lockfile` [#40]

### DIFF
--- a/env/production/terraform.tf
+++ b/env/production/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0"
+  required_version = ">= 1.10.0"
   required_providers {
     aws = {
       source  = "registry.terraform.io/hashicorp/aws"
@@ -21,8 +21,8 @@ terraform {
     # Non-default workspaces use s3://nextstrain-terraform/workspace/${name}/infra/production/tfstate
     workspace_key_prefix = "workspace"
 
-    # Table has a LockID (string) partition/primary key
-    dynamodb_table = "nextstrain-terraform-locks"
+    # use an S3-based .tflock file as a semaphore
+    use_lockfile = true
   }
 }
 


### PR DESCRIPTION
## Description of proposed changes

Changes from using the (deprecated) `dynamodb_table` argument in the `terraform.backend.s3` stanza to the (supported) `use_lockfile` argument.

This preserves the state-locking/semaphore behavior that prevents multiple people from simultaneously changing the Terraform state, without emitting a warning about the use of a deprecated option (which is going to be removed in a future minor version update of Terraform, so this fix heads off actual future breakage too). 

## Related issue(s)

Closes #40 

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
