### PR TITLE
add lifecycle to move all objects uploaded to `nextstrain-archive` to intelligent tiering, right away [#182]

### DIFF
--- a/env/production/aws-s3-bucket-nextstrain-archive.tf
+++ b/env/production/aws-s3-bucket-nextstrain-archive.tf
@@ -11,6 +11,25 @@ resource "aws_s3_bucket_versioning" "nextstrain-archive" {
   }
 }
 
+resource "aws_s3_bucket_lifecycle_configuration" "nextstrain-archive" {
+  bucket = aws_s3_bucket.nextstrain-archive.id
+
+  rule {
+    id = "all-intelligent-tiering"
+
+    # we want everything in this bucket to go into the intelligent
+    # tiering storage class
+    filter {}
+
+    transition {
+      days          = 0
+      storage_class = "INTELLIGENT_TIERING"
+    }
+
+    status = "Enabled"
+  }
+}
+
 resource "aws_s3_bucket_ownership_controls" "nextstrain-archive" {
   bucket = aws_s3_bucket.nextstrain-archive.id
 


### PR DESCRIPTION
## Description of proposed changes

My original plan was to set this bucket to default to "intelligent tiering" for the storage level -- but you can't set a default storage class on a bucket.

Instead, I have added a lifecycle configuration that transitions all objects to the "intelligent tiering" storage class after 0 days — so, effectively, when things are uploaded, they will immediately move to "intelligent tiering".

## Related issue(s)

#46 
<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
