### PR TITLE
Add `chikv` to supported pathogen repos

### DIFF
--- a/env/production/locals.tf
+++ b/env/production/locals.tf
@@ -13,6 +13,7 @@ locals {
     # pathogen name   = [repo name, …]
     "avian-flu"       = ["avian-flu"],
     "dengue"          = ["dengue"],
+    "chikv"           = ["chikv"],
     "forecasts-ncov"  = ["forecasts-ncov"],
     "hmpv"            = ["hmpv"],
     "lassa"           = ["lassa"],


### PR DESCRIPTION
## Description of proposed changes

Prompted by https://github.com/nextstrain/chikv/pull/1 which includes the addition of a GH Action workflow that uses pathogen-repo-build workflow.

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Post-merge: `terraform -chdir=env/production apply plan`
- ~[ ] Update changelog~


<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
