### PR TITLE
Special-case forecasts-flu access to seasonal-flu

### DIFF
--- a/env/production/aws-iam-role-GitHubActionsRoleNextstrainRepo@.tf
+++ b/env/production/aws-iam-role-GitHubActionsRoleNextstrainRepo@.tf
@@ -41,6 +41,11 @@ resource "aws_iam_role" "GitHubActionsRoleNextstrainRepo" {
       ? [aws_iam_policy.NextstrainPathogenNcovPrivateReadOnly.arn]
       : [],
 
+    # Special-case forecasts-flu repo
+    each.key == "forecasts-flu"
+    ? [aws_iam_policy.NextstrainPathogen["seasonal-flu"].arn]
+    : [],
+
     # Builds inside the AWS Batch runtime need access to the jobs bucket.
     aws_iam_policy.NextstrainJobsAccessToBucket.arn,
   ])


### PR DESCRIPTION
## Description of proposed changes

Adds permissions for forecasts-flu to access resources for seasonal-flu. As @tsibley pointed out in a similar commit for forecasts-ncov [1], the split between a forecasts-flu repo and the seasonal-flu repo is a conceptual one that has reasonable alternatives like placing a "forecasts" workflow inside the seasonal-flu repo.

[1] https://github.com/nextstrain/infra/commit/4bccaf084b513444df133fb3afedaec8a7db14da

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

Related to #52 

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [ ] Update changelog

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
