### PR TITLE
Replace special-case conditional with a declaration in the pathogen to repo map

### DIFF
--- a/env/production/aws-iam-role-GitHubActionsRoleNextstrainRepo@.tf
+++ b/env/production/aws-iam-role-GitHubActionsRoleNextstrainRepo@.tf
@@ -41,11 +41,6 @@ resource "aws_iam_role" "GitHubActionsRoleNextstrainRepo" {
       ? [aws_iam_policy.NextstrainPathogenNcovPrivateReadOnly.arn]
       : [],
 
-    # Special-case forecasts-flu repo
-    each.key == "forecasts-flu"
-    ? [aws_iam_policy.NextstrainPathogen["seasonal-flu"].arn]
-    : [],
-
     # Builds inside the AWS Batch runtime need access to the jobs bucket.
     aws_iam_policy.NextstrainJobsAccessToBucket.arn,
   ])

--- a/env/production/locals.tf
+++ b/env/production/locals.tf
@@ -29,7 +29,7 @@ locals {
     "rsv"             = ["rsv"],
     "rubella"         = ["rubella"],
     "seasonal-cov"    = ["seasonal-cov"],
-    "seasonal-flu"    = ["seasonal-flu"],
+    "seasonal-flu"    = ["seasonal-flu", "forecasts-flu"],
     "tb"              = ["tb"],
     "WNV"             = ["WNV"],
     "yellow-fever"    = ["yellow-fever"],


### PR DESCRIPTION
Declares the seasonal-flu pathogen resources should be manageable by the forecasts-flu repo.

This reverts commit "Special-case forecasts-flu access to seasonal-flu" (da429f7) to achieve the same result a different way.


## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [ ] Update changelog

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
