### PR TITLE
Migrate batch jobs from AL2 to AL2023

### DIFF
--- a/env/production/aws-batch.tf
+++ b/env/production/aws-batch.tf
@@ -10,7 +10,7 @@ resource "aws_batch_job_queue" "nextstrain_job_queue" {
 
   compute_environment_order {
     order               = 1
-    compute_environment = aws_batch_compute_environment.c5_instances_2023_01_17.arn
+    compute_environment = aws_batch_compute_environment.c5_instances_2026_05_19.arn
   }
 }
 


### PR DESCRIPTION
## Description of proposed changes

Follow-up to #64 after successful testing. The [migration guide](https://docs.aws.amazon.com/batch/latest/userguide/ecs-migration-2023.html) does not seem to contain anything noteworthy for our usage.

Keeping the test job queue around for future testing, and the old compute environment around in case we need to revert back to it for any reason.

## Related issue(s)

Closes #62

## Checklist

- [x] Manually tested the new compute environment using `NEXTSTRAIN_AWS_BATCH_QUEUE=nextstrain-job-queue-test nextstrain build --aws-batch zika-tutorial` ([link to batch job](https://us-east-1.console.aws.amazon.com/batch/home?region=us-east-1#/jobs/ec2/detail/061cf333-de9b-4f83-b55b-6c23b4191181))
- [x] Checks pass
- [x] Post-merge: `terraform apply plan` and monitor

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
