### PR TITLE
aws-batch: Import new compute environment for C7a instances

### DIFF
--- a/env/production/aws-batch.tf
+++ b/env/production/aws-batch.tf
@@ -10,7 +10,7 @@ resource "aws_batch_job_queue" "nextstrain_job_queue" {
 
   compute_environment_order {
     order               = 1
-    compute_environment = aws_batch_compute_environment.c5_instances_2026_05_19.arn
+    compute_environment = aws_batch_compute_environment.c7a_instances_2026_05_24.arn
   }
 }
 
@@ -77,6 +77,45 @@ resource "aws_batch_compute_environment" "c5_instances_2026_05_19" {
     # dynamically instead of hardcoding them here.
     security_group_ids  = ["sg-09316f4e9077adc8c"]
     subnets             = ["subnet-ece172e0"]
+    type                = "EC2"
+
+    ec2_configuration {
+      image_type = "ECS_AL2023"
+    }
+
+    # TODO: Import the launch template into Terraform and pull its name
+    # dynamically instead of hardcoding it here.
+    launch_template {
+      launch_template_name = "nextstrain-jobs-aws-batch"
+      version              = "14"
+    }
+  }
+}
+
+import {
+  to = aws_batch_compute_environment.c7a_instances_2026_05_24
+  id = "c7a-instances-2026-05-24"
+}
+
+resource "aws_batch_compute_environment" "c7a_instances_2026_05_24" {
+  name         = "c7a-instances-2026-05-24"
+  service_role = "arn:aws:iam::827581582529:role/aws-service-role/batch.amazonaws.com/AWSServiceRoleForBatch"
+  state        = "ENABLED"
+  type         = "MANAGED"
+
+  compute_resources {
+    allocation_strategy = "BEST_FIT"
+    bid_percentage      = 0
+    desired_vcpus       = 4
+    instance_role       = "arn:aws:iam::827581582529:instance-profile/ecsInstanceRole"
+    instance_type       = ["c7a.2xlarge", "c7a.4xlarge", "c7a.8xlarge", "c7a.large", "c7a.medium", "c7a.xlarge"]
+    max_vcpus           = 512
+    min_vcpus           = 0
+    # TODO: Import VPC resources into Terraform and pull their IDs
+    # dynamically instead of hardcoding them here.
+    security_group_ids  = ["sg-09316f4e9077adc8c"]
+    subnets             = ["subnet-ece172e0"]
+    tags                = {}
     type                = "EC2"
 
     ec2_configuration {


### PR DESCRIPTION
This is already being used for nextstrain-job-queue.

Plan shows "1 to import" with no resource action indicators (the imported resource will not be changed).

https://bedfordlab.slack.com/archives/C01LCTT7JNN/p1779670308514829

## Checklist

- [x] Checks pass
