### PR TITLE
batch: Add new job queue and compute environment with larger instance

### DIFF
--- a/env/production/aws-batch.tf
+++ b/env/production/aws-batch.tf
@@ -106,7 +106,15 @@ resource "aws_batch_compute_environment" "c7a_instances_2026_05_24" {
   compute_resources {
     allocation_strategy = "BEST_FIT"
     instance_role       = "arn:aws:iam::827581582529:instance-profile/ecsInstanceRole"
-    instance_type       = ["c7a.2xlarge", "c7a.4xlarge", "c7a.8xlarge", "c7a.large", "c7a.medium", "c7a.xlarge"]
+    # Details: https://aws.amazon.com/ec2/pricing/on-demand/
+    instance_type = [
+      "c7a.medium",
+      "c7a.large",
+      "c7a.xlarge",
+      "c7a.2xlarge",
+      "c7a.4xlarge",
+      "c7a.8xlarge",
+    ]
     max_vcpus           = 512
     min_vcpus           = 0
     # TODO: Import VPC resources into Terraform and pull their IDs

--- a/env/production/aws-batch.tf
+++ b/env/production/aws-batch.tf
@@ -25,6 +25,17 @@ resource "aws_batch_job_queue" "nextstrain_job_queue_test" {
   }
 }
 
+resource "aws_batch_job_queue" "nextstrain_job_queue_c7a_12xlarge" {
+  name     = "nextstrain-job-queue-c7a-12xlarge"
+  priority = 1
+  state    = "ENABLED"
+
+  compute_environment_order {
+    order               = 1
+    compute_environment = aws_batch_compute_environment.c7a_12xlarge.arn
+  }
+}
+
 import {
   to = aws_batch_compute_environment.c5_instances_2023_01_17
   id = "c5-instances-2023-01-17"
@@ -114,6 +125,46 @@ resource "aws_batch_compute_environment" "c7a_instances_2026_05_24" {
       "c7a.2xlarge",
       "c7a.4xlarge",
       "c7a.8xlarge",
+    ]
+    max_vcpus           = 512
+    min_vcpus           = 0
+    # TODO: Import VPC resources into Terraform and pull their IDs
+    # dynamically instead of hardcoding them here.
+    security_group_ids  = ["sg-09316f4e9077adc8c"]
+    subnets             = ["subnet-ece172e0"]
+    type                = "EC2"
+
+    ec2_configuration {
+      image_type = "ECS_AL2023"
+    }
+
+    # TODO: Import the launch template into Terraform and pull its name
+    # dynamically instead of hardcoding it here.
+    launch_template {
+      launch_template_name = "nextstrain-jobs-aws-batch"
+      version              = "14"
+    }
+  }
+}
+
+resource "aws_batch_compute_environment" "c7a_12xlarge" {
+  name         = "c7a-instances-2026-05-24"
+  service_role = "arn:aws:iam::827581582529:role/aws-service-role/batch.amazonaws.com/AWSServiceRoleForBatch"
+  state        = "ENABLED"
+  type         = "MANAGED"
+
+  compute_resources {
+    allocation_strategy = "BEST_FIT"
+    instance_role       = "arn:aws:iam::827581582529:instance-profile/ecsInstanceRole"
+    # Details: https://aws.amazon.com/ec2/pricing/on-demand/
+    instance_type = [
+      "c7a.medium",
+      "c7a.large",
+      "c7a.xlarge",
+      "c7a.2xlarge",
+      "c7a.4xlarge",
+      "c7a.8xlarge",
+      "c7a.12xlarge",
     ]
     max_vcpus           = 512
     min_vcpus           = 0


### PR DESCRIPTION
## Description of proposed changes

Motivation is to allow GISAID ingest to run with more memory (it failed with c7a.8xlarge).

Use with `--aws-batch-queue nextstrain-job-queue-c7a-12xlarge`.

Plan: 2 to add, 0 to change, 0 to destroy.

## Related issue(s)

https://github.com/nextstrain/ncov-ingest/issues/532

## Checklist

- [x] Checks pass
