### PR TITLE
Support GitHub Actions OIDC immutable subject claims

### DIFF
--- a/env/production/aws-iam-role-GitHubActionsRoleNextstrainBatchJobs.tf
+++ b/env/production/aws-iam-role-GitHubActionsRoleNextstrainBatchJobs.tf
@@ -24,7 +24,7 @@ resource "aws_iam_role" "GitHubActionsRoleNextstrainBatchJobs" {
             "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
             "token.actions.githubusercontent.com:sub": flatten([
               [for repo in keys(local.repo_pathogens):
-                "repo:nextstrain/${repo}:*:job_workflow_ref:nextstrain/.github/.github/workflows/pathogen-repo-build.yaml@*"],
+                "${local.repo_sub_prefixes[repo]}:*:job_workflow_ref:nextstrain/.github/.github/workflows/pathogen-repo-build.yaml@*"],
 
               # Special case for seasonal flu repo which needs to download the private builds
               # from AWS Batch before bundling/deploying them through Netlify.

--- a/env/production/aws-iam-role-GitHubActionsRoleNextstrainRepo@.tf
+++ b/env/production/aws-iam-role-GitHubActionsRoleNextstrainRepo@.tf
@@ -19,7 +19,7 @@ resource "aws_iam_role" "GitHubActionsRoleNextstrainRepo" {
         "Condition": {
           "StringLike": {
             "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
-            "token.actions.githubusercontent.com:sub": "repo:nextstrain/${each.key}:*:job_workflow_ref:nextstrain/.github/.github/workflows/pathogen-repo-build.yaml@*"
+            "token.actions.githubusercontent.com:sub": "${local.repo_sub_prefixes[each.key]}:*:job_workflow_ref:nextstrain/.github/.github/workflows/pathogen-repo-build.yaml@*"
           }
         },
       }

--- a/env/production/locals.tf
+++ b/env/production/locals.tf
@@ -48,4 +48,27 @@ locals {
       ".github" = [],
     }),
   )
+
+  # repo name → id for repos that use immutable subject claims.
+  # To get this value, go to GitHub > repo settings > Actions > OIDC and inspect
+  # the value for "Default subject claim prefix". Example value:
+  #
+  #     repo:nextstrain@22159334/hantavirus@1307765855
+  #
+  repo_ids = tomap({
+    "hantavirus" = "1307765855"
+  })
+
+  # OIDC sub claim prefixes.
+  repo_sub_prefixes = {
+    for repo in keys(local.repo_pathogens) :
+    repo => (
+      # If the repo has an id, use the immutable format.
+      contains(keys(local.repo_ids), repo)
+      ? "repo:nextstrain@22159334/${repo}@${local.repo_ids[repo]}"
+
+      # Otherwise, use the legacy format ("repo:nextstrain/repo").
+      : "repo:nextstrain/${repo}"
+    )
+  }
 }


### PR DESCRIPTION
## Description of proposed changes

GitHub uses [immutable subject claims](https://docs.github.com/en/actions/reference/security/oidc#immutable-subject-claims) for newly created/renamed repositories, formatting the sub claim as
`repo:OWNER@OWNER-ID/REPO@REPO-ID`.

Add a mapping of repo name → id, and dynamically create the sub claim prefix to support both immutable and legacy formats.

## Related issue(s)

Follow-up to #76

## Checklist

- [x] apply plan + run workflow successfully
- [x] Checks pass
